### PR TITLE
Update yellow to match Dracula color palette

### DIFF
--- a/conf.d/dracula.fish
+++ b/conf.d/dracula.fish
@@ -4,7 +4,7 @@ set -l comment    6272a4
 
 set -l red    ff5555
 set -l orange ffb86c
-set -l yellow f4f99d
+set -l yellow f1fa8c
 set -l green  50fa7b
 set -l cyan   8be9fd
 set -l pink   ff79c6


### PR DESCRIPTION
All the colors should match the Dracula color palette now: https://github.com/dracula/dracula-theme#color-palette

The difference is pretty minor, but there's no reason this theme shouldn't be in line with the official Dracula color palette.

Before: ![Screen Shot 2020-05-20 at 2 19 32 PM](https://user-images.githubusercontent.com/6618434/82488150-0dcc5e00-9aa5-11ea-81b3-0be4d6005b16.png)

After: ![Screen Shot 2020-05-20 at 2 19 45 PM](https://user-images.githubusercontent.com/6618434/82488159-12911200-9aa5-11ea-98ef-502a75b65904.png)
