### PR TITLE
fix: correct fisher install command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 If you use [Fisher](https://github.com/jorgebucaran/fisher) to manage your `fish` plugins:
 
 ```
-fisher add dracula/fish
+fisher install dracula/fish
 ```
 
 If you use [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish) to manage your `fish` plugins:


### PR DESCRIPTION
```
~/.dotfiles on master •
❯ fisher add dracula/fish
fisher: unknown flag or command: "add" (see `fisher -h`)

~/.dotfiles on master •
❯ fisher install dracula/fish
fisher install version 4.1.0
fetching https://codeload.github.com/dracula/fish/tar.gz/HEAD
installing dracula/fish
           /Users/carlos/.config/fish/conf.d/dracula.fish
installed 1 plugin/s
```