### PR TITLE
Support for dracula theme file (Fish >=3.4)

### DIFF
--- a/themes/dracula.theme
+++ b/themes/dracula.theme
@@ -1,0 +1,56 @@
+# Dracula Color Palette
+#
+# foreground: f8f8f2
+# selection:  44475a
+# comment:    6272a4
+# red:        ff5555
+# orange:     ffb86c
+# yellow:     f1fa8c
+# green:      50fa7b
+# purple:     bd93f9
+# cyan:       8be9fd
+# pink:       ff79c6
+
+# Syntax Highlighting Colors
+fish_color_normal f8f8f2
+fish_color_command 8be9fd
+fish_color_keyword ff79c6
+fish_color_quote f1fa8c
+fish_color_redirection f8f8f2
+fish_color_end ffb86c
+fish_color_error ff5555
+fish_color_param bd93f9
+fish_color_comment 6272a4
+fish_color_selection --background=44475a
+fish_color_search_match --background=44475a
+fish_color_operator 50fa7b
+fish_color_escape ff79c6
+fish_color_autosuggestion 6272a4
+fish_color_cancel ff5555 --reverse
+fish_color_option ffb86c
+fish_color_history_current --bold
+fish_color_match --background=8be9fd
+fish_color_status ff5555
+fish_color_valid_path --underline
+
+# Default Prompt Colors
+fish_color_cwd 50fa7b
+fish_color_cwd_root red
+fish_color_host bd93f9
+fish_color_host_remote bd93f9
+fish_color_user 8be9fd
+
+# Completion Pager Colors
+fish_pager_color_progress 6272a4
+fish_pager_color_background
+fish_pager_color_prefix 8be9fd
+fish_pager_color_completion f8f8f2
+fish_pager_color_description 6272a4
+fish_pager_color_selected_background --background=44475a
+fish_pager_color_selected_prefix 8be9fd
+fish_pager_color_selected_completion f8f8f2
+fish_pager_color_selected_description 6272a4
+fish_pager_color_secondary_background
+fish_pager_color_secondary_prefix 8be9fd
+fish_pager_color_secondary_completion f8f8f2
+fish_pager_color_secondary_description 6272a4


### PR DESCRIPTION
In March 2022, Fish released [version 3.4](https://github.com/fish-shell/fish-shell/releases/tag/3.4.0), which defined a new way of handling themes. Setting themes no longer involves explicitly setting variables and instead uses `.theme` files in the `themes` directory (aka: `$__fish_conf_dir/themes`).

So, basically instead of something like `~/.config/fish/conf.d/dracula.fish` to set a bunch of variables, you'd use `~/.config/fish/themes/dracula.theme`. Doing themes this way gives support for the builtin theme configuration commands: `fish_config theme (choose | demo | dump | list | save | show)`, as well as makes dracula appear in Fish's web config interface.

This PR adds the `dracula.theme` file, but does not remove support for older versions of Fish, nor does it force the use of a `.theme` file. If a user wants to use the new themes feature in a modern version of Fish (3.4-3.6 and beyond), they need only install dracula using Fisher or OMF as the instructions describe. (Fisher already supports theme plugins, not sure about OMF yet, but this PR is still safe because the default install is still the old way prior to themes.)

Once installed via their plugin manager, a user can then simply drop an empty `dracula.fish` in their `conf.d` to override the one that comes with this project if they want to use the `dracula.theme` file. The theme file can then be used by using the Fish built-in `fish_config` command. Dracula can then be selected either via the web interface, or by running `fish_config theme choose dracula`. This also allows Dracula to be installed alongside other great themes (eg: Tokyo Night).